### PR TITLE
A bug caused by a typo causes execute_script event object to not have a script id

### DIFF
--- a/lib/Propagator.php
+++ b/lib/Propagator.php
@@ -898,7 +898,7 @@ class Propagator {
             } elseif (!empty($details['propagate_script_instance_deployment_id'])) {
                 $queried_info = $this->data_model->get_propagate_script_and_instance_and_deployment(null, $details['propagate_script_instance_deployment_id']);
                 if (!empty($queried_info[0]['propagate_script_id'])) {
-                    $event['script_id']   = $queried_info[0]['propagator_script_id'];
+                    $event['script_id']   = $queried_info[0]['propagate_script_id'];
                     $event['description'] = $queried_info[0]['description'];
                     $event['schema']      = $queried_info[0]['default_schema'];
                     $event['role']        = $queried_info[0]['database_role_id'];


### PR DESCRIPTION
I've been working on using the new event listeners to have propagator start sending messages to our dev chat room. However, I noticed that when an execute_script event would fire, that the script_id property in the event object would be empty. Upon further inspection, turns out there is a typo in lib/Propagator.php that was causing problems with assigning the proper script id.
